### PR TITLE
Add age requirement clause A6 with jurisdiction extensions for Canada

### DIFF
--- a/core/age-requirements/A6.md
+++ b/core/age-requirements/A6.md
@@ -1,0 +1,32 @@
+# A6 - Must Be Over 18
+
+## Clause Text
+
+Users must be at least eighteen (18) years of age to access or use the Service. By accessing or using the Service, you represent and warrant that you are at least eighteen (18) years old.
+
+## Purpose
+
+This clause establishes a minimum age requirement of 18 years for using the service, which is particularly important for services involving:
+- Adult content or services
+- Financial transactions
+- Legal agreements requiring full contractual capacity
+- Alcohol, tobacco, or other age-restricted products
+
+## Key Elements
+
+1. **Age Threshold**: Explicitly sets the minimum age at 18 years
+2. **User Representation**: Users must affirm they meet the age requirement
+3. **Access Restriction**: Applies to both accessing and using the service
+
+## Considerations
+
+- Some jurisdictions may have different age of majority requirements
+- Services involving alcohol may need jurisdiction-specific variations (see extensions)
+- Consider whether parental consent options are needed for younger users
+- May need to implement age verification mechanisms
+
+## Related Clauses
+
+- AGE0 - Basic age requirement clause
+- Privacy policies regarding minors
+- Terms regarding parental consent

--- a/core/age-requirements/extensions/A6-CA-AB.md
+++ b/core/age-requirements/extensions/A6-CA-AB.md
@@ -1,0 +1,13 @@
+# A6-CA-AB - Must Be Over 18 (Alberta, Canada)
+
+## Clause Text
+
+Users must be at least eighteen (18) years of age to access or use the Service. By accessing or using the Service, you represent and warrant that you are at least eighteen (18) years old.
+
+## Jurisdiction-Specific Notes
+
+In Alberta, Canada:
+- Legal drinking age: 18 years
+- Age of majority: 18 years
+
+This clause aligns with Alberta's provincial regulations for age-restricted services, particularly those involving alcohol.

--- a/core/age-requirements/extensions/A6-CA-BC.md
+++ b/core/age-requirements/extensions/A6-CA-BC.md
@@ -1,0 +1,13 @@
+# A6-CA-BC - Must Be Over 19 (British Columbia, Canada)
+
+## Clause Text
+
+Users must be at least nineteen (19) years of age to access or use the Service. By accessing or using the Service, you represent and warrant that you are at least nineteen (19) years old.
+
+## Jurisdiction-Specific Notes
+
+In British Columbia, Canada:
+- Legal drinking age: 19 years
+- Age of majority: 19 years
+
+This variation adjusts the age requirement to comply with British Columbia's provincial regulations, particularly for services involving alcohol.

--- a/core/age-requirements/extensions/A6-CA-ON.md
+++ b/core/age-requirements/extensions/A6-CA-ON.md
@@ -1,0 +1,13 @@
+# A6-CA-ON - Must Be Over 19 (Ontario, Canada)
+
+## Clause Text
+
+Users must be at least nineteen (19) years of age to access or use the Service. By accessing or using the Service, you represent and warrant that you are at least nineteen (19) years old.
+
+## Jurisdiction-Specific Notes
+
+In Ontario, Canada:
+- Legal drinking age: 19 years
+- Age of majority: 18 years
+
+This variation sets the age requirement at 19 to comply with Ontario's alcohol regulations, even though the age of majority is 18.

--- a/docs/JURISDICTIONS.md
+++ b/docs/JURISDICTIONS.md
@@ -1,0 +1,87 @@
+# Jurisdiction Extensions Guide
+
+## Overview
+
+The Teas & Seas framework supports jurisdiction-specific variations of clauses through an extension system. This allows legal clauses to be adapted to local laws and regulations while maintaining a consistent base structure.
+
+## Naming Convention
+
+### Base Clauses
+- Base clauses use simple identifiers (e.g., `A6`, `P5`, `L3`)
+- These represent the standard, generic version of a clause
+
+### Jurisdiction Extensions
+- Extensions add jurisdiction codes after the base identifier
+- Format: `[BaseID]-[CountryCode]-[RegionCode]`
+- Examples:
+  - `A6-CA-AB` - Age clause for Alberta, Canada
+  - `A6-CA-BC` - Age clause for British Columbia, Canada
+  - `P5-EU` - Privacy clause for European Union
+  - `L3-US-CA` - Liability clause for California, USA
+
+## Important Usage Notes
+
+1. **When referencing clauses generally**, use the base identifier:
+   - "Our terms include clause A6" ✓
+   - "We comply with P5 requirements" ✓
+
+2. **When referencing specific jurisdictions**, include the full extension:
+   - "In British Columbia, we use A6-CA-BC" ✓
+   - "California users are subject to L3-US-CA" ✓
+
+3. **For users in a specific jurisdiction**, the base identifier suffices:
+   - If you're in Canada and know your province, just refer to "A6"
+   - The appropriate jurisdiction-specific version will apply
+
+## Directory Structure
+
+Jurisdiction extensions are organized within each clause category:
+
+```
+core/
+├── age-requirements/
+│   ├── AGE0.md
+│   ├── A6.md
+│   └── extensions/
+│       ├── A6-CA-AB.md
+│       ├── A6-CA-BC.md
+│       └── A6-CA-ON.md
+├── privacy/
+│   ├── P0.md
+│   └── extensions/
+│       └── P0-EU.md
+```
+
+## Creating New Extensions
+
+When local laws require variations:
+
+1. Create an `extensions/` folder in the relevant clause category
+2. Name the file using the convention: `[BaseID]-[Jurisdiction].md`
+3. Include:
+   - Modified clause text
+   - Jurisdiction-specific notes
+   - References to relevant local laws
+   - Explanation of differences from base clause
+
+## Common Jurisdiction Codes
+
+### Countries
+- `CA` - Canada
+- `US` - United States
+- `UK` - United Kingdom
+- `EU` - European Union
+- `AU` - Australia
+
+### Canadian Provinces
+- `AB` - Alberta
+- `BC` - British Columbia
+- `ON` - Ontario
+- `QC` - Quebec
+- (etc.)
+
+### US States
+- `CA` - California
+- `NY` - New York
+- `TX` - Texas
+- (etc.)


### PR DESCRIPTION
Implements a flexible age restriction system that supports jurisdiction-specific variations. Includes base A6 clause (18+) with extensions for Canadian provinces where drinking age differs (AB=18, BC/ON=19). Also adds comprehensive documentation for the jurisdiction extension naming convention.

🤖 Generated with [Claude Code](https://claude.ai/code)