### PR TITLE
Complete Liability clause levels 7-8

### DIFF
--- a/core/liability/L7.md
+++ b/core/liability/L7.md
@@ -1,0 +1,21 @@
+# L7 v1.0.0
+
+## Liability (Level 7)
+
+### 📌 Summary
+Extremely limited liability capped at $10 with comprehensive exclusions and no warranties.
+
+### 👤 What This Means For You
+This liability level is designed for very low-cost or experimental services where the business model cannot support meaningful liability coverage. The $10 cap represents a token acknowledgment of potential issues while making clear that users should not rely on the service for critical purposes. This is appropriate for hobby projects, educational tools, or services operating on minimal budgets where users understand they're essentially using the service at their own risk.
+
+### 📜 Legal Text
+Provider's total aggregate liability arising from or related to this agreement shall not exceed $10 USD. Service is provided strictly "as is" without any warranties, express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, or non-infringement. Provider expressly disclaims liability for: any indirect, incidental, special, consequential, or punitive damages; loss of data, profits, revenue, or business opportunities; service interruptions or failures; third-party claims; or any damages resulting from reliance on the service. User assumes all risks associated with service use.
+
+### 🔍 Examples
+- Hobby projects with minimal support
+- Educational or demonstration services
+- Ultra-low-cost tools with clear limitations
+
+---
+*Version History*
+- v1.0.0 - Initial version

--- a/core/liability/L8.md
+++ b/core/liability/L8.md
@@ -1,0 +1,21 @@
+# L8 v1.0.0
+
+## Liability (Level 8)
+
+### 📌 Summary
+Near-complete liability disclaimer with only token acknowledgment of legal minimums.
+
+### 👤 What This Means For You
+This level approaches a complete liability disclaimer while acknowledging that some jurisdictions may not permit total disclaimers. The service is provided with the understanding that users bear essentially all risk. This is typically used for free services, experimental projects, or situations where the provider cannot reasonably guarantee any particular outcome. Users should treat this as effectively having no recourse and should not use the service for anything they cannot afford to lose.
+
+### 📜 Legal Text
+To the fullest extent permitted by law, Provider's liability is limited to the minimum amount required by applicable law, if any. The service is provided "as is" and "as available" without any warranties whatsoever. Provider disclaims all liability for any damages of any kind, including but not limited to: direct, indirect, incidental, consequential, punitive, and special damages; loss of use, data, profits, or business opportunities; and any claims by third parties. Where jurisdictions do not allow complete disclaimers, liability is limited to the minimum extent permitted. User expressly assumes all risks.
+
+### 🔍 Examples
+- Free experimental tools
+- Open-source projects without support
+- Services with prominent risk warnings
+
+---
+*Version History*
+- v1.0.0 - Initial version


### PR DESCRIPTION
## Summary
- Adds missing intermediate Liability levels L7 and L8
- Completes the full 0-9 progression for Liability clauses
- Bridges the gap between L6 (minimal liability) and L9 (complete disclaimer)

## Changes
- **L7**: Extremely limited liability with $10 cap for hobby/educational services
- **L8**: Near-complete disclaimer with token acknowledgment of legal minimums

## Test plan
- [x] Review that L7 provides appropriate progression from L6
- [x] Review that L8 appropriately bridges to L9
- [x] Verify formatting matches existing clause structure
- [x] Confirm examples are relevant and distinct

🤖 Generated with [Claude Code](https://claude.ai/code)