### PR TITLE
Update CLAUDE.md to reference TODO.txt for priorities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,8 @@ Each clause file must include:
 - Avoid inflammatory terms like "aggressive," "unfair," or "hostile"
 - Examples should reference legitimate business contexts, not assume malicious intent
 
-### Current Priorities (from TODO.txt)
-- Complete intermediate levels (1-4, 6-8) for existing clause types
-- Age requirement extensions for various jurisdictions
-- Build clause builder tool
-- Create badge generator
-- Develop validation tools
+### Current Priorities
+- See `TODO.txt` for up-to-date priorities and tasks
 
 ### Contributing
 - See `/docs/CONTRIBUTING.md` for detailed guidelines


### PR DESCRIPTION
## Summary
- Remove hardcoded priority list from CLAUDE.md
- Point to TODO.txt as single source of truth for current priorities

## Why This Change?
The hardcoded priority list in CLAUDE.md will inevitably become outdated as priorities change. Instead of maintaining duplicate information, this PR updates CLAUDE.md to reference TODO.txt for current priorities and tasks.

🤖 Generated with [Claude Code](https://claude.ai/code)