### PR TITLE
Fix inflammatory language in payment clauses

### DIFF
--- a/core/payment/PAY7.md
+++ b/core/payment/PAY7.md
@@ -3,18 +3,19 @@
 ## Payment (Level 7)
 
 ### 📌 Summary
-Highly unfavorable payment - aggressive billing, no protections, excessive penalties.
+Strict payment terms - comprehensive billing rights, limited refunds, substantial penalties.
 
 ### 👤 What This Means For You
-Expect aggressive billing practices with charges for everything imaginable. No refunds ever, prices spike without warning, and hidden fees are everywhere. Your payment method will be charged repeatedly and disputing charges leads to severe penalties. Cancellation is extremely difficult and expensive.
+Payment terms heavily favor the provider with broad billing rights, no refund policy, and ability to change prices without notice. Multiple fee categories apply and disputes may result in penalties and account termination. Cancellation requires adherence to strict procedures and may incur fees.
 
 ### 📜 Legal Text
 ABSOLUTE NO-REFUND POLICY. Unlimited price increases at provider discretion without notice. Mandatory charges include access fees, platform fees, transaction fees, inactivity fees, and any fees we deem necessary. Minimum commitment periods with severe early termination penalties. Disputes result in account termination, collections referral, and minimum $500 penalty. You authorize perpetual charging rights and waive all consumer protections.
 
 ### 🔍 Examples
-- Predatory billing schemes
-- Services under regulatory investigation
-- Known "billing trap" companies
+- High-risk financial services requiring strict payment security
+- Services with significant fraud exposure or chargebacks
+- International platforms with complex regulatory compliance
+- Subscription services with high content licensing costs
 
 ---
 *Version History*

--- a/core/payment/PAY8.md
+++ b/core/payment/PAY8.md
@@ -3,18 +3,19 @@
 ## Payment (Level 8)
 
 ### 📌 Summary
-Extreme payment exploitation - unlimited charges, no recourse, financial entrapment.
+Maximum payment flexibility for provider - unlimited billing authority, no refunds, perpetual rights.
 
 ### 👤 What This Means For You
-By agreeing, you give unlimited access to charge your payment methods for any amount at any time. No possibility of refunds, no ability to dispute charges, and no way to stop future billing. Prices change constantly and retroactively. This represents complete loss of financial control to the provider.
+You grant the provider unrestricted billing authorization with no refund options or dispute rights. Pricing can change at any time including retroactive adjustments. Billing rights continue even after account termination. All financial risk and liability rests with the user.
 
 ### 📜 Legal Text
 User grants irrevocable authorization for unlimited charges at provider's sole discretion. No refunds, chargebacks, or disputes permitted under any circumstances. Prices fluctuate without notice including retroactive adjustments. Perpetual billing rights survive account closure. User liable for all fees including speculative damages, lost profits, and punitive charges. Personal liability extends beyond corporate veils. Collection costs, legal fees, and compound interest at maximum legal rate apply.
 
 ### 🔍 Examples
-- Financial exploitation schemes
-- Services with class-action lawsuits
-- Extreme predatory practices
+- Ultra-high-risk financial instruments or trading platforms
+- Services operating in heavily sanctioned environments
+- Platforms with extreme regulatory burdens requiring indemnification
+- Services with uncapped potential liability exposure
 
 ---
 *Version History*

--- a/core/payment/PAY9.md
+++ b/core/payment/PAY9.md
@@ -3,18 +3,19 @@
 ## Payment (Level 9)
 
 ### 📌 Summary
-Aggressive payment terms - no refunds, instant price changes, auto-renewal traps, hidden fees.
+Business-protective payment terms - no refunds, flexible pricing, mandatory auto-renewal, comprehensive fees.
 
 ### 👤 What This Means For You
-Once you pay, the money is gone forever - no refunds under any circumstances. Prices can change instantly without notice. Cancellation is difficult and may require written notice. Hidden fees, automatic upgrades, and surprise charges are likely. Your payment method will be charged aggressively for any reason we determine.
+All sales are final with no refund options. The provider can adjust prices immediately without advance notice. Auto-renewal is mandatory and cancellation requires following specific procedures including written notice. Various fees may apply beyond the base price, and the provider has broad discretion in billing decisions.
 
 ### 📜 Legal Text
 ALL SALES FINAL. NO REFUNDS. Prices subject to change without notice, effective immediately. Automatic renewal is mandatory with no grace period. Cancellation requires 90 days written notice sent by certified mail. We may charge for overages, access, support, features, or any reason at our sole discretion. You authorize recurring charges and waive chargeback rights. Additional fees, penalties, and interest apply for any dispute. You are responsible for all collection costs.
 
 ### 🔍 Examples
-- Predatory subscription services
-- Services with "bill shock" reputations
-- Companies featured in consumer complaints
+- High-value enterprise software with significant implementation costs
+- Services with volatile underlying costs (e.g., cloud infrastructure, API usage)
+- Platforms requiring extensive fraud prevention measures
+- International services with complex tax and regulatory compliance
 
 ---
 *Version History*


### PR DESCRIPTION
## Summary
- Rewrite PAY7, PAY8, and PAY9 to remove inflammatory language
- Maintain neutrality while explaining both user impact and business rationale
- Update examples to reference legitimate business needs

## Changes Made

### PAY7
- Changed "aggressive billing" → "comprehensive billing rights"
- Changed "predatory billing schemes" → legitimate examples like "high-risk financial services"

### PAY8
- Changed "extreme payment exploitation" → "maximum payment flexibility for provider"
- Changed "financial exploitation schemes" → legitimate examples like "ultra-high-risk financial instruments"

### PAY9
- Changed "aggressive payment terms" → "business-protective payment terms"
- Changed "predatory subscription services" → legitimate examples like "high-value enterprise software"

## Context
This PR implements the tone and neutrality guidelines established in #17. The updated clauses now:
- Use neutral, factual language
- Explain legitimate business reasons for strict terms (regulatory compliance, fraud prevention, risk management)
- Avoid characterizing businesses as malicious or predatory
- Present user-business tensions as natural balance

🤖 Generated with [Claude Code](https://claude.ai/code)