### PR TITLE
Complete all intellectual property clause levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Each clause includes:
 | **AU** | [Acceptable Use](core/acceptable-use/) | Usage restrictions | [AU0](core/acceptable-use/AU0.md), [AU5](core/acceptable-use/AU5.md), [AU9](core/acceptable-use/AU9.md) |
 | **D** | [Disputes](core/disputes/) | Conflict resolution | [D0](core/disputes/D0.md), [D5](core/disputes/D5.md), [D9](core/disputes/D9.md) |
 | **C** | [Cookies](core/cookies/) | Cookie & tracking policies | [C0](core/cookies/C0.md), [C5](core/cookies/C5.md), [C9](core/cookies/C9.md) |
+| **IP** | [Intellectual Property](core/intellectual-property/) | IP ownership & licensing | [IP0](core/intellectual-property/IP0.md), [IP5](core/intellectual-property/IP5.md), [IP9](core/intellectual-property/IP9.md) |
 
 ### 🚧 In Progress
 
 | Code | Type | Description | Status |
 |------|------|-------------|--------|
-| **IP** | [Intellectual Property](core/intellectual-property/) | IP ownership & licensing | Levels 0, 5, 9 only |
 | **S** | [Severability](core/severability/) | Invalid clause handling | Level 0 only |
 | **AGE** | [Age Requirements](core/age-requirements/) | Age restrictions | Levels 0, 6 only |
 | **General** | [General](core/general/) | Misc. terms | Being restructured |

--- a/core/intellectual-property/IP1.md
+++ b/core/intellectual-property/IP1.md
@@ -1,0 +1,21 @@
+# IP1 v1.0.0
+
+## Intellectual Property (Level 1)
+
+### 📌 Summary
+Minimal IP claims - we keep basic rights, generous permissions for users.
+
+### 👤 What This Means For You
+We maintain ownership of our core service but grant you broad permissions to use, share, and build upon it. You can freely use our name in reviews, create tutorials, and develop integrations. We only restrict direct copying of our code or misrepresenting your relationship with us.
+
+### 📜 Legal Text
+Provider retains ownership of the service and associated IP but grants users a broad, perpetual license for most uses. Users may create derivative works, integrations, and educational content. Trademark use permitted for identification and commentary. No warranty of non-infringement provided. Users retain all rights to their content with no license back to Provider except for service operation.
+
+### 🔍 Examples
+- Developer-friendly platforms
+- Services encouraging ecosystem growth
+- Educational technology providers
+
+---
+*Version History*
+- v1.0.0 - Initial version

--- a/core/intellectual-property/IP2.md
+++ b/core/intellectual-property/IP2.md
@@ -1,0 +1,21 @@
+# IP2 v1.0.0
+
+## Intellectual Property (Level 2)
+
+### 📌 Summary
+Light IP protection - basic ownership with user-friendly permissions.
+
+### 👤 What This Means For You
+We own our service and branding, but you have significant freedom to use and reference them. You can create complementary tools, write about us, and use our APIs. You just can't clone our service or use our trademarks in misleading ways. Your content remains yours with minimal license to us.
+
+### 📜 Legal Text
+Provider owns all IP in the service including copyrights, trademarks, and patents. Users receive a non-exclusive license to use the service. Fair use, commentary, and non-commercial derivatives permitted. API usage allowed per documentation. Users grant Provider limited license to host and display user content solely for service operation. No claim to user-generated IP beyond operational needs.
+
+### 🔍 Examples
+- API-first companies
+- Platforms with third-party developers
+- Services with active user communities
+
+---
+*Version History*
+- v1.0.0 - Initial version

--- a/core/intellectual-property/IP3.md
+++ b/core/intellectual-property/IP3.md
@@ -1,0 +1,21 @@
+# IP3 v1.0.0
+
+## Intellectual Property (Level 3)
+
+### 📌 Summary
+Moderate IP protection - clear ownership boundaries with reasonable use rights.
+
+### 👤 What This Means For You
+We maintain clear ownership of our service, technology, and brands. You get standard usage rights and can reference us appropriately. Integration and automation are allowed within terms of service limits. Your content is yours, but you grant us operational licenses. Some restrictions on competitive use.
+
+### 📜 Legal Text
+Provider exclusively owns all service IP including software, designs, marks, and methods. User receives limited, revocable license during term. No reverse engineering or decompilation. Trademark use requires compliance with brand guidelines. Users retain content ownership but grant Provider worldwide license to use, modify, and display content for service provision and improvement. Non-compete restrictions may apply.
+
+### 🔍 Examples
+- Enterprise software companies
+- Services with proprietary algorithms
+- Platforms balancing openness with protection
+
+---
+*Version History*
+- v1.0.0 - Initial version

--- a/core/intellectual-property/IP4.md
+++ b/core/intellectual-property/IP4.md
@@ -1,0 +1,21 @@
+# IP4 v1.0.0
+
+## Intellectual Property (Level 4)
+
+### 📌 Summary
+Balanced IP protection - standard commercial terms with typical restrictions.
+
+### 👤 What This Means For You
+Standard software IP terms apply. We own our service and technology; you own your content. You can use the service as intended but can't copy, modify, or reverse engineer it. Normal fair use and commentary allowed. We need certain rights to your content to run the service effectively.
+
+### 📜 Legal Text
+All service IP remains Provider's exclusive property. User granted non-transferable license for authorized use only. Prohibited: reverse engineering, creating derivative works, or competitive use. Users grant Provider license to use, store, and process user content for service operation, security, and analytics. Feedback and suggestions become Provider property. Standard fair use and first sale doctrines apply.
+
+### 🔍 Examples
+- Standard B2B software
+- Mainstream SaaS platforms  
+- Traditional software licensing
+
+---
+*Version History*
+- v1.0.0 - Initial version

--- a/core/intellectual-property/IP6.md
+++ b/core/intellectual-property/IP6.md
@@ -1,0 +1,21 @@
+# IP6 v1.0.0
+
+## Intellectual Property (Level 6)
+
+### 📌 Summary
+Strong IP protection - comprehensive rights with limited user permissions.
+
+### 👤 What This Means For You
+We assert strong ownership over all aspects of our service with limited usage rights granted to you. Most forms of analysis, integration, or derivative use require explicit permission. We claim rights to aggregated data and certain improvements suggested by users. Your content remains yours but with broader operational licenses to us.
+
+### 📜 Legal Text
+Provider asserts all IP rights including patents pending and trade secrets. Strictly limited license for personal/internal business use only. All forms of analysis, benchmarking, or competitive use prohibited. Provider claims rights to aggregated data, usage patterns, and improvements. Users grant broad license for content including promotional use and derivative works. Moral rights waived where applicable.
+
+### 🔍 Examples
+- Financial trading platforms
+- Services with valuable data or algorithms
+- High-security enterprise systems
+
+---
+*Version History*
+- v1.0.0 - Initial version

--- a/core/intellectual-property/IP7.md
+++ b/core/intellectual-property/IP7.md
@@ -1,0 +1,21 @@
+# IP7 v1.0.0
+
+## Intellectual Property (Level 7)
+
+### 📌 Summary
+Extensive IP protection - broad claims with minimal user rights and significant restrictions.
+
+### 👤 What This Means For You
+The provider claims extensive IP rights with minimal permissions granted to users. Even basic uses may require explicit authorization. The provider asserts rights to user-generated improvements, feedback, and usage data. Significant restrictions on discussing or analyzing the service publicly. Violations carry substantial penalties.
+
+### 📜 Legal Text
+Provider claims maximum IP protection including method patents and trade dress. User license limited to internal use with no public discussion rights. All user contributions, feedback, and insights become Provider property. No right to benchmark, analyze, or discuss service functionality. Provider claims database rights and all derivatives. Violation penalties include liquidated damages and injunctive relief. Indemnification required.
+
+### 🔍 Examples
+- Proprietary trading systems
+- Services with critical competitive advantages
+- Platforms in heavily litigious industries
+
+---
+*Version History*
+- v1.0.0 - Initial version

--- a/core/intellectual-property/IP8.md
+++ b/core/intellectual-property/IP8.md
@@ -1,0 +1,21 @@
+# IP8 v1.0.0
+
+## Intellectual Property (Level 8)
+
+### 📌 Summary
+Near-maximum IP protection - expansive rights claims with severe restrictions and penalties.
+
+### 👤 What This Means For You
+The provider asserts IP rights that extend beyond the service itself to related concepts and methods. Users receive only the most basic access rights with no ability to analyze, discuss, or build upon the service. Any feedback or interaction may transfer IP rights to the provider. Enforcement includes both monetary damages and criminal prosecution references.
+
+### 📜 Legal Text
+Provider claims all current and future IP rights in service domain. Any user interaction constitutes assignment of related IP to Provider. No rights granted except minimal access. Criminal prosecution for trade secret violation threatened. All user ideas, whether shared or not, subject to Provider claims if related to service area. Pre-invention assignment required. $250,000 minimum damages per violation.
+
+### 🔍 Examples
+- Defense contractors with classified systems
+- Ultra-high-value IP holdings
+- Services facing extreme competitive threats
+
+---
+*Version History*
+- v1.0.0 - Initial version

--- a/core/intellectual-property/IP9.md
+++ b/core/intellectual-property/IP9.md
@@ -3,18 +3,19 @@
 ## Intellectual Property (Level 9)
 
 ### 📌 Summary
-Extreme IP claims including rights to user ideas, aggressive enforcement, broad restrictions.
+Maximum IP protection with comprehensive rights claims, strict enforcement, and extensive restrictions.
 
 ### 👤 What This Means For You
-We claim rights to everything - not just our service but potentially your ideas, feedback, and anything you create using our tools. You can't mention us without permission, can't interoperate with our service, and we might claim you're infringing our patents just for using common features. We aggressively enforce these rights.
+The provider claims extensive intellectual property rights including the service, user submissions, feedback, and derivative works. Use is restricted to the narrow license granted, with no rights to mention, link, reverse engineer, or create interoperable products. Patent claims may cover broad method and process concepts. All IP rights are actively enforced with significant penalties for violations.
 
 ### 📜 Legal Text
 Provider asserts maximum IP rights including future patents on any concept within service domain. User grants rights to all ideas, feedback, and suggestions. Any use beyond narrow license is infringement. No right to mention, link, reverse engineer, compete, or interoperate. Provider claims trade dress, look-and-feel, and method patents broadly. User indemnifies against all IP claims. Liquidated damages of $100,000 per violation.
 
 ### 🔍 Examples
-- Patent trolls
-- Companies known for IP lawsuits
-- Services with extreme IP positions
+- High-value proprietary technology companies
+- Services with critical trade secrets or algorithms
+- Platforms with extensive patent portfolios
+- Industries with high IP litigation risk
 
 ---
 *Version History*


### PR DESCRIPTION
## Summary
- Complete the intellectual property clause type with all levels 0-9
- Fix IP9 to align with neutrality guidelines
- Update README to reflect completion

## What This PR Adds

### New IP Clause Levels
- **IP1**: Minimal IP claims with generous user permissions
- **IP2**: Light protection with user-friendly permissions  
- **IP3**: Moderate protection with reasonable use rights
- **IP4**: Balanced protection with standard commercial terms
- **IP6**: Strong protection with limited user permissions
- **IP7**: Extensive protection with minimal user rights
- **IP8**: Near-maximum protection with severe restrictions

### Updates
- Fixed IP9 to remove inflammatory language ("patent trolls" → legitimate business contexts)
- Updated README to move IP from "In Progress" to "Complete" section

## Milestone Achieved 🎉
With this PR, **all 10 major clause types now have complete 0-9 level coverage**:
- Privacy (P)
- Liability (L) 
- Warranty (W)
- Termination (T)
- Payment (PAY)
- User Content (UC)
- Acceptable Use (AU)
- Disputes (D)
- Cookies (C)
- Intellectual Property (IP)

The core clause library is now complete\! Only minor clause types (Severability, Age Requirements, General) remain in progress.

🤖 Generated with [Claude Code](https://claude.ai/code)